### PR TITLE
fix(registry): deregister use tag to find version and appId

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -162,7 +162,6 @@ func (scr *serviceCombRegistry) Register(info *registry.Info) error {
 		HostName:    scr.opts.hostName,
 		HealthCheck: healthCheck,
 		Status:      sc.MSInstanceUP,
-		Properties:  info.Tags,
 	})
 	if err != nil {
 		return fmt.Errorf("register service instance error: %w", err)
@@ -215,7 +214,7 @@ func (scr *serviceCombRegistry) Deregister(info *registry.Info) error {
 		addr := host + ":" + port
 
 		instanceId := ""
-		instances, err := scr.cli.FindMicroServiceInstances("", info.Tags["app_id"], info.ServiceName, info.Tags["version"], sc.WithoutRevision())
+		instances, err := scr.cli.FindMicroServiceInstances("", scr.opts.appId, info.ServiceName, scr.opts.versionRule, sc.WithoutRevision())
 		if err != nil {
 			return fmt.Errorf("get instances error: %w", err)
 		}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -160,10 +160,6 @@ func TestSCMultipleInstances(t *testing.T) {
 	err = got.Deregister(&registry.Info{
 		ServiceName: ServiceName,
 		Addr:        &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 8083},
-		Tags: map[string]string{
-			"app_id":  AppId,
-			"version": LatestVersion,
-		},
 	})
 	assert.Nil(t, err)
 	_, err = client.FindMicroServiceInstances("", AppId, ServiceName, LatestVersion, sc.WithoutRevision())


### PR DESCRIPTION
替换从Tags取数据的逻辑